### PR TITLE
Remove unused finishPath action and share hexToHsl helper

### DIFF
--- a/remediation-report.md
+++ b/remediation-report.md
@@ -1,0 +1,20 @@
+# Remediation Report
+
+## Overview
+A review of the codebase identified one unused action in the canvas store and duplicated color conversion helpers in two utility modules. The work completed in this change removes the unused action and centralises the shared colour conversion logic so that future improvements touch a single well-tested helper.
+
+## Unused Code
+### `finishPath` canvas action
+- **Location:** `src/store/canvasStore.ts`
+- **Issue:** The `finishPath` action was exposed through the `useCanvasStore` interface but was never invoked by any component or hook. Keeping the noop action inflated the public API of the store, which increases maintenance costs and can mislead contributors into thinking additional cleanup is required when finishing pencil operations.
+- **Remediation:** The action has been removed from both the store type definition and the store implementation. This keeps the public surface area focused on actively supported workflows.
+
+## Duplicated Code
+### Hex-to-HSL conversion helpers
+- **Locations:** `src/utils/opticalAlignmentUtils.ts` and `src/utils/presets.ts`
+- **Issue:** Each module declared an almost identical `hexToHsl` helper. Maintaining two copies of the same algorithm risks logic drift and forces future fixes to be applied twice. For example, enhancing colour validation would have required touching both files.
+- **Remediation:** A shared `hexToHsl` helper now lives in `src/utils/canvasColorUtils.ts`. Both modules import the centralised function, eliminating duplication while keeping consistent return semantics for existing callers.
+
+## Follow-up Opportunities
+- Consider extracting additional colour utilities (such as the inline `hexToRgb` helper inside `getContrastingColor`) into the same shared module when the need arises. This will further reduce duplication as colour handling evolves.
+- If new pencil-tool lifecycle hooks are required in the future, document them clearly in the store so their responsibilities are easy to audit. Keeping the store API lean makes it easier to spot genuinely unused behaviour.

--- a/src/store/canvasStore.ts
+++ b/src/store/canvasStore.ts
@@ -56,7 +56,6 @@ export type CanvasStore = BaseSlice &
     // Additional actions that need cross-slice functionality
     startPath: (point: Point) => void;
     addPointToPath: (point: Point) => void;
-    finishPath: () => void;
     addText: (x: number, y: number, text: string) => Promise<void>;
     deleteSelectedElements: () => void;
     createShape: (startPoint: Point, endPoint: Point) => void;
@@ -189,10 +188,6 @@ export const useCanvasStore = create<CanvasStore>()(
               },
             });
           }
-        },
-
-        finishPath: () => {
-          // Path is already added, nothing special to do
         },
 
         addText: async (x, y, text) => {

--- a/src/utils/canvasColorUtils.ts
+++ b/src/utils/canvasColorUtils.ts
@@ -98,3 +98,45 @@ export const getEffectiveColorForContrast = (
  * Special subpath selection color
  */
 export const SUBPATH_SELECTION_COLOR = '#8b5cf6'; // Purple to indicate subpath mode
+
+/**
+ * Convert a hex color string to its HSL representation.
+ *
+ * This helper centralises the logic used by multiple modules that need to work
+ * with chromatic values (e.g. optical alignment metrics and preset sorting).
+ * Returning a consistent object shape prevents repeated tuple/object
+ * conversions in the callers.
+ */
+export function hexToHsl(hex: string): { h: number; s: number; l: number } {
+  const normalized = hex.replace('#', '');
+
+  const r = parseInt(normalized.substring(0, 2), 16) / 255;
+  const g = parseInt(normalized.substring(2, 4), 16) / 255;
+  const b = parseInt(normalized.substring(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return { h: h * 360, s: s * 100, l: l * 100 };
+}

--- a/src/utils/opticalAlignmentUtils.ts
+++ b/src/utils/opticalAlignmentUtils.ts
@@ -1,6 +1,7 @@
 import type { Point, Command, PathData, CanvasElement } from '../types';
 import { measurePath } from './measurementUtils';
 import { formatToPrecision, PATH_DECIMAL_PRECISION } from './index';
+import { hexToHsl } from './canvasColorUtils';
 
 // Types for optical alignment
 export interface PathGeometry {
@@ -287,38 +288,6 @@ function calculateWeightVariance(weights: QuadrantWeights): number {
   const mean = values.reduce((sum, val) => sum + val, 0) / values.length;
   const variance = values.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / values.length;
   return formatToPrecision(variance, PATH_DECIMAL_PRECISION);
-}
-
-/**
- * Converts a hex color to HSL for better visual weight calculation
- */
-function hexToHsl(hex: string): { h: number; s: number; l: number } {
-  // Remove # if present
-  hex = hex.replace('#', '');
-  
-  // Convert to RGB
-  const r = parseInt(hex.substr(0, 2), 16) / 255;
-  const g = parseInt(hex.substr(2, 2), 16) / 255;
-  const b = parseInt(hex.substr(4, 2), 16) / 255;
-  
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const l = (max + min) / 2
-  let h = 0, s = 0;
-  
-  if (max !== min) {
-    const d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-    
-    switch (max) {
-      case r: h = (g - b) / d + (g < b ? 6 : 0); break;
-      case g: h = (b - r) / d + 2; break;
-      case b: h = (r - g) / d + 4; break;
-    }
-    h /= 6;
-  }
-  
-  return { h: h * 360, s: s * 100, l: l * 100 };
 }
 
 /**

--- a/src/utils/presets.ts
+++ b/src/utils/presets.ts
@@ -1,3 +1,5 @@
+import { hexToHsl } from './canvasColorUtils';
+
 export interface Preset {
   id: string;
   name: string;
@@ -6,32 +8,6 @@ export interface Preset {
   strokeOpacity: number;
   fillColor: string;
   fillOpacity: number;
-}
-
-// Helper function to convert hex to HSL
-function hexToHsl(hex: string): [number, number, number] {
-  const r = parseInt(hex.slice(1, 3), 16) / 255;
-  const g = parseInt(hex.slice(3, 5), 16) / 255;
-  const b = parseInt(hex.slice(5, 7), 16) / 255;
-
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  let h = 0;
-  let s = 0;
-  const l = (max + min) / 2;
-
-  if (max !== min) {
-    const d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-    switch (max) {
-      case r: h = (g - b) / d + (g < b ? 6 : 0); break;
-      case g: h = (b - r) / d + 2; break;
-      case b: h = (r - g) / d + 4; break;
-    }
-    h /= 6;
-  }
-
-  return [h * 360, s * 100, l * 100];
 }
 
 // Get the primary color for sorting (stroke if available, otherwise fill)
@@ -144,8 +120,8 @@ export const PRESETS: Preset[] = [
     if (colorB === '#808080' && colorA !== '#808080') return -1;
     if (colorA === '#808080' && colorB === '#808080') return 0;
 
-    const [hueA] = hexToHsl(colorA);
-    const [hueB] = hexToHsl(colorB);
+    const { h: hueA } = hexToHsl(colorA);
+    const { h: hueB } = hexToHsl(colorB);
 
     return hueA - hueB;
   })


### PR DESCRIPTION
## Summary
- remove the unused `finishPath` action from the canvas store and document the audit results
- centralize the hex to HSL conversion helper in `canvasColorUtils` and reuse it in optical alignment and preset utilities
- add a remediation report that outlines the unused and duplicated code findings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da90d508048331aa5504e43935bb99